### PR TITLE
Call printStackTrace() only in debug build

### DIFF
--- a/SDK/appwoodoo/src/main/java/com/appwoodoo/sdk/io/HttpsClient.java
+++ b/SDK/appwoodoo/src/main/java/com/appwoodoo/sdk/io/HttpsClient.java
@@ -14,6 +14,8 @@ import java.util.Map;
 
 import android.os.AsyncTask;
 
+import com.appwoodoo.sdk.BuildConfig;
+
 public class HttpsClient {
 
 	// until a connection is established (in millis)
@@ -86,7 +88,9 @@ public class HttpsClient {
         try {
             url = new URL(urlString);
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            if (BuildConfig.DEBUG) {
+                e.printStackTrace();
+            }
             // URL should be hard-coded in the SDK, so we we shouldn't ever be here.
             // Therefore there is no way to recover from this.
             throw new IOException();

--- a/SDK/appwoodoo/src/main/java/com/appwoodoo/sdk/model/RemoteSetting.java
+++ b/SDK/appwoodoo/src/main/java/com/appwoodoo/sdk/model/RemoteSetting.java
@@ -1,5 +1,7 @@
 package com.appwoodoo.sdk.model;
 
+import com.appwoodoo.sdk.BuildConfig;
+
 import java.util.ArrayList;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -51,7 +53,9 @@ public class RemoteSetting {
 			}
 
 		} catch(Exception e) {
-			e.printStackTrace();
+			if (BuildConfig.DEBUG) {
+				e.printStackTrace();
+			}
 		}
 		
 		return woodoos;

--- a/SDK/appwoodoo/src/main/java/com/appwoodoo/sdk/push/PushNotificationHelper.java
+++ b/SDK/appwoodoo/src/main/java/com/appwoodoo/sdk/push/PushNotificationHelper.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
 
+import com.appwoodoo.sdk.BuildConfig;
 import com.appwoodoo.sdk.io.DeviceApiHandler;
 import com.appwoodoo.sdk.state.Config;
 import com.appwoodoo.sdk.state.State;
@@ -116,7 +117,9 @@ public class PushNotificationHelper {
 			notificationManager.notify(Config.NOTIFICATION_REQCODE, builder.build());
 
 		} catch (ClassNotFoundException e) {
-			e.printStackTrace();
+			if (BuildConfig.DEBUG) {
+				e.printStackTrace();
+			}
 		}
 
 	}


### PR DESCRIPTION
This would be very useful to not log exceptions in production mode
